### PR TITLE
Implement auto-downgrade of throttled formats

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -24,7 +24,7 @@ In summary, DLYT is a handy tool for batch downloading and organizing videos fro
 - `--no-aria2c` - disable the use of `aria2c` as an external downloader.
 - `--prefer-aria2c` - warn if `aria2c` is not installed and prefer using it when available.
 - `--use-aria2c` - force using `aria2c` even for YouTube links.
-- `--force-best-quality` - allow throttled formats like VP9/itag 313 for 4K downloads.
+- `--force-best-quality` - use the highest quality even if it's a throttled VP9/AV1 format. Without this flag, DLYT auto-downgrades to fast MP4 1080p when throttling is detected.
 
 Please remember to replace the placeholders in the URLs with actual values before running DLYT. Happy downloading!
 


### PR DESCRIPTION
## Summary
- warn about throttled VP9/AV1 formats
- auto-select 1080p mp4 for YouTube when throttling is detected
- allow overriding with `--force-best-quality`

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685700126bdc8333852b9bfb0782bc1e