### PR TITLE
Improve startup feedback when URLs exist

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -317,8 +317,11 @@ fn main() -> io::Result<()> {
     let base_dir = "videos";
     let archive_file = "downloaded.txt";
 
-    if create_default_structure(dir_path)? {
+    let created = create_default_structure(dir_path)?;
+    if created {
         return Ok(());
+    } else {
+        println!("Found existing {} directory. Processing .urls files...", dir_path);
     }
 
     let urls_exist = process_url_files(


### PR DESCRIPTION
## Summary
- print a message when the `urls` directory already exists

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_685703417a5c83338e054253fa3509ef