### PR TITLE
Add skip-probe option

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -25,6 +25,7 @@ In summary, DLYT is a handy tool for batch downloading and organizing videos fro
 - `--prefer-aria2c` - warn if `aria2c` is not installed and prefer using it when available.
 - `--use-aria2c` - force using `aria2c` even for YouTube links.
 - `--force-best-quality` - use the highest quality even if it's a throttled VP9/AV1 format. Without this flag, DLYT auto-downgrades to fast MP4 1080p when throttling is detected.
+- `--skip-probe` - skip the initial format probe for faster startup (may miss auto-downgrade warnings).
 
 Please remember to replace the placeholders in the URLs with actual values before running DLYT. Happy downloading!
 


### PR DESCRIPTION
## Summary
- add `--skip-probe` CLI flag to skip format probing
- support skipping probing in download logic
- document the new option

## Testing
- `cargo test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68570e8e2bec8333b2c0efef70e2e351