### PR TITLE
Invert probing flag

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -25,7 +25,7 @@ In summary, DLYT is a handy tool for batch downloading and organizing videos fro
 - `--prefer-aria2c` - warn if `aria2c` is not installed and prefer using it when available.
 - `--use-aria2c` - force using `aria2c` even for YouTube links.
 - `--force-best-quality` - use the highest quality even if it's a throttled VP9/AV1 format. Without this flag, DLYT auto-downgrades to fast MP4 1080p when throttling is detected.
-- `--skip-probe` - skip the initial format probe for faster startup (may miss auto-downgrade warnings).
+- `--probe` - perform an initial format probe to warn about throttled formats (slightly slower startup).
 
 Please remember to replace the placeholders in the URLs with actual values before running DLYT. Happy downloading!
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,9 +29,9 @@ struct Args {
     #[arg(long)]
     force_best_quality: bool,
 
-    /// Skip probing formats with yt-dlp -J for faster startup
+    /// Probe formats with yt-dlp -J to detect throttling
     #[arg(long)]
-    skip_probe: bool,
+    probe: bool,
 }
 
 fn command_exists(cmd: &str) -> bool {
@@ -206,7 +206,7 @@ fn process_url_files(
     base_use_aria2c: bool,
     force_aria2c: bool,
     force_best_quality: bool,
-    skip_probe: bool,
+    probe: bool,
 ) -> io::Result<bool> {
     let mut urls_exist = false;
 
@@ -236,10 +236,10 @@ fn process_url_files(
                 let is_youtube = domain.contains("youtube.com") || domain.contains("youtu.be");
 
                 let (format_str, warn_throttled, downgraded) = if is_youtube {
-                    if skip_probe {
-                        select_format_without_probe(force_best_quality)
-                    } else {
+                    if probe {
                         select_format(&url, force_best_quality)?
+                    } else {
+                        select_format_without_probe(force_best_quality)
                     }
                 } else if force_best_quality {
                     ("bestvideo+bestaudio/best".to_string(), false, false)
@@ -353,7 +353,7 @@ fn main() -> io::Result<()> {
         base_use_aria2c,
         force_aria2c,
         force_best_quality,
-        args.skip_probe,
+        args.probe,
     )?;
 
     if !urls_exist {


### PR DESCRIPTION
## Summary
- rename `--skip-probe` flag to `--probe` so probing is opt-in
- update README with new flag description

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68571d59972c8333940086612d8490a7